### PR TITLE
[RFC] allow conversion of ConfParse to a Dict

### DIFF
--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -417,4 +417,7 @@ Check if a key exists inside an ini file block.
 """
 haskey(s::ConfParse, block::String, key::String) = haskey(s._data, lowercase(block)) && haskey(s._data[lowercase(block)], key)
 
+Base.Dict(s::ConfParse) = s._data
+Base.convert(::Type{Dict}, s::ConfParse) = s._data
+
 end # module ConfParser


### PR DESCRIPTION
This PR adds the ability to request a `Dict(s::ConfParse)` which just retrieves the internally stored dict. `Dict(s::ConfParse)` and `convert` are the two methods I guess most users would try if they want to get a Dict back.