### PR TITLE
Simplify `erase!` and remove usage of `getkey`

### DIFF
--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -275,9 +275,9 @@ end
 Remove entry from ini block.
 """
 function erase!(s::ConfParse, block::String, key::String)
-    block_key = lowercase(block)
-    if haskey(s._data, block_key) && haskey(s._data[block_key], key)
-        delete!(s._data[block_key], key)
+    block = get(s._data, lowercase(block), nothing)
+    if block !== nothing && haskey(block, key)
+        delete!(block, key)
         s._is_modified = true
     end
     s._is_modified

--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -275,12 +275,10 @@ end
 Remove entry from ini block.
 """
 function erase!(s::ConfParse, block::String, key::String)
-    block_key = getkey(s._data, lowercase(block), nothing)
-    if block_key !== nothing
-        if haskey(s._data[block_key], key)
-            delete!(s._data[block_key], key)
-            s._is_modified = true
-        end
+    block_key = lowercase(block)
+    if haskey(s._data, block_key) && haskey(s._data[block_key], key)
+        delete!(s._data[block_key], key)
+        s._is_modified = true
     end
     s._is_modified
 end


### PR DESCRIPTION
The usage of `getkey` here is a roundabout way of writing `haskey`. This computes one fewer hash and avoids the use of `getkey`, an obscure function that is rarely useful and less likely to be as well maintained or efficiently implemented as `get`.